### PR TITLE
Fix script to ensure it works on macOS

### DIFF
--- a/scripts/get-remote-credentials.sh
+++ b/scripts/get-remote-credentials.sh
@@ -35,12 +35,12 @@ echo "-------"
 echo "token |"
 echo "-------"
 echo
-echo -n $BASE64_BEARER_TOKEN | base64 -d
+echo -n $BASE64_BEARER_TOKEN | base64 --decode
 echo
 echo
 echo "-----"
 echo "ca: |"
 echo "-----"
 echo
-echo -n $BASE64_CA_FILE | base64 -d
+echo -n $BASE64_CA_FILE | base64 --decode
 echo


### PR DESCRIPTION
Original `base64 -d` only works for Linux. Changed to --decode to make
it work on both macs and linux.