### PR TITLE
bump minimist -> 1.2.5 to remove security warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2841,9 +2841,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jsonist": "^2.1.0",
     "jsonwebtoken": "^8.5.0",
     "knex": "^0.21.1",
-    "minimist": "^1.2.0",
+    "minimist": "^1.2.5",
     "mkdirp": "^0.5.1",
     "node-cidr": "^1.0.0",
     "passport": "^0.4.0",


### PR DESCRIPTION
Signed-off-by: Kai Davenport <kaiyadavenport@gmail.com>