### PR TITLE
feat(migration): add deployment_method to deployment table

### DIFF
--- a/migrations/202007210800_add_deployment_method.js
+++ b/migrations/202007210800_add_deployment_method.js
@@ -1,0 +1,19 @@
+
+const up = (knex) => {
+  return Promise.all([
+    knex.schema.table('deployment', (table) => {
+      table.text('deployment_method').defaultTo('classic')
+    }),
+  ])
+}
+
+const down = (knex) => {
+  return Promise.all([
+    knex.schema.dropTable('deployment')
+  ])
+}
+
+module.exports = {
+  up,
+  down
+}


### PR DESCRIPTION
defaults to 'classic' and allows for legacy classic deployments and more precise differentiation of deployment methods

sxt-419

Signed-off-by: Mikeala Sheldt <mikaela@blockchaintp.com>