### PR TITLE
fix(migrations): correct the down methods on migrations

### DIFF
--- a/migrations/201910231055_drop_add_deployment_constraint.js
+++ b/migrations/201910231055_drop_add_deployment_constraint.js
@@ -12,7 +12,12 @@ const up = (knex) => {
 
 const down = (knex) => {
   return Promise.all([
-    knex.schema.dropTable('deployment')
+    knex.schema.table('deployment', (table) => {
+      table.dropUnique(['name','cluster'])
+    }),
+    knex.schema.alterTable('deployment', (table) => {
+      table.unique(['name'])
+    })
   ])
 }
 

--- a/migrations/201912200704_add_yaml_column.js
+++ b/migrations/201912200704_add_yaml_column.js
@@ -9,8 +9,10 @@ const up = (knex) => {
 
 const down = (knex) => {
   return Promise.all([
-    knex.schema.dropTable('deployment')
-  ])
+    knex.schema.table('deployment', (table) => {
+      table.dropColumn('custom_yaml')
+    })
+  ]);
 }
 
 module.exports = {

--- a/migrations/202002101308_add_resource_status.js
+++ b/migrations/202002101308_add_resource_status.js
@@ -9,7 +9,9 @@ const up = (knex) => {
 
 const down = (knex) => {
   return Promise.all([
-    knex.schema.dropTable('task')
+    knex.schema.table('task', (table) => {
+      table.dropColumn('resource_status')
+    }),
   ])
 }
 

--- a/migrations/202006011128_deployment_type_enum.js
+++ b/migrations/202006011128_deployment_type_enum.js
@@ -14,6 +14,16 @@ const formatAlterTableEnumSql = (
   ].join('\n');
 };
 
+const dropConstraintSql = (
+  tableName,
+  columnName
+) => {
+  const constraintName = `${tableName}_${columnName}_check`;
+  return [
+    `ALTER TABLE ${tableName} DROP CONSTRAINT IF EXISTS ${constraintName};`,
+  ].join('\n');
+};
+
 
 exports.up = async function up(knex) {
   await knex.raw(
@@ -22,5 +32,7 @@ exports.up = async function up(knex) {
 };
 
 exports.down = async function down(knex) {
-  
+  await knex.raw(
+    dropConstraintSql('deployment','deployment_type')
+  );
 };

--- a/migrations/202007210800_add_deployment_method.js
+++ b/migrations/202007210800_add_deployment_method.js
@@ -9,7 +9,9 @@ const up = (knex) => {
 
 const down = (knex) => {
   return Promise.all([
-    knex.schema.dropTable('deployment')
+    knex.schema.table('deployment', (table) => {
+      table.dropColumn('deployment_method')
+    }),
   ])
 }
 


### PR DESCRIPTION
Various of the migrations were doing dropTable as their down method, where this was not the reverse of the up.  This can prove disastrous if ever a rollback was needed.

Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>