### PR TITLE
feat(form-string-array): configure the image pull secrets to be an ar…

### DIFF
--- a/src/deployment_templates/daml/daml-on-postgres/320-daml-on-pg-set.yaml
+++ b/src/deployment_templates/daml/daml-on-postgres/320-daml-on-pg-set.yaml
@@ -24,7 +24,7 @@ spec:
       {{ if .imagePullSecrets.enabled }}
       imagePullSecrets:
       {{range .imagePullSecrets.value }}
-        - name: {{ .name }}
+        - name: {{ . }}
       {{ end }}
       {{ end }}
       containers:

--- a/src/deployment_templates/daml/daml-on-postgres/form.js
+++ b/src/deployment_templates/daml/daml-on-postgres/form.js
@@ -125,6 +125,9 @@ const form = [
       visibilityParameter: 'true' // for what value of linkedId, will this component be visible
     },
     list: {
+      // this means we want an array of the `name` fields
+      // NOT an array of objects each with a name field
+      extractField: 'name',
       mainField: 'name',
       schema: [{
         id: 'name',

--- a/src/deployment_templates/daml/daml-on-qldb/320-daml-on-qldb-set.yaml
+++ b/src/deployment_templates/daml/daml-on-qldb/320-daml-on-qldb-set.yaml
@@ -24,7 +24,7 @@ spec:
       {{ if .imagePullSecrets.enabled }}
       imagePullSecrets:
       {{range .imagePullSecrets.value }}
-        - name: {{ .name }}
+        - name: {{ . }}
       {{ end }}
       {{ end }}
       containers:

--- a/src/deployment_templates/daml/daml-on-qldb/form.js
+++ b/src/deployment_templates/daml/daml-on-qldb/form.js
@@ -84,6 +84,9 @@ const form = [
     helperText: null,
     default: null,
     list: {
+      // this means we want an array of the `name` fields
+      // NOT an array of objects each with a name field
+      extractField: 'name',
       mainField: 'name',
       schema: [{
         id: 'name',

--- a/src/deployment_templates/daml/daml-on-sawtooth/210-monitoring-set.yaml
+++ b/src/deployment_templates/daml/daml-on-sawtooth/210-monitoring-set.yaml
@@ -27,7 +27,7 @@ spec:
       {{ if .imagePullSecrets.enabled }}
       imagePullSecrets:
       {{range .imagePullSecrets.value }}
-        - name: {{ .name }}
+        - name: {{ . }}
       {{ end }}
       {{ end }}
       containers:

--- a/src/deployment_templates/daml/daml-on-sawtooth/320-validator-set.yaml
+++ b/src/deployment_templates/daml/daml-on-sawtooth/320-validator-set.yaml
@@ -43,7 +43,7 @@ spec:
       {{ if .imagePullSecrets.enabled }}
       imagePullSecrets:
       {{range .imagePullSecrets.value }}
-        - name: {{ .name }}
+        - name: {{ . }}
       {{ end }}
       {{ end }}
       hostAliases:

--- a/src/deployment_templates/daml/daml-on-sawtooth/330-sawtooth-daml-rpc.yaml
+++ b/src/deployment_templates/daml/daml-on-sawtooth/330-sawtooth-daml-rpc.yaml
@@ -25,7 +25,7 @@ spec:
       {{ if .imagePullSecrets.enabled }}
       imagePullSecrets:
       {{range .imagePullSecrets.value }}
-        - name: {{ .name }}
+        - name: {{ . }}
       {{ end }}
       {{ end }}
       containers:

--- a/src/deployment_templates/daml/daml-on-sawtooth/form.js
+++ b/src/deployment_templates/daml/daml-on-sawtooth/form.js
@@ -267,6 +267,9 @@ const form = [
       visibilityParameter: 'true' // for what value of linkedId, will this component be visible
     },
     list: {
+      // this means we want an array of the `name` fields
+      // NOT an array of objects each with a name field
+      extractField: 'name',
       mainField: 'name',
       schema: [{
         id: 'name',

--- a/src/deployment_templates/sawtooth/1.1/210-monitoring-set.yaml
+++ b/src/deployment_templates/sawtooth/1.1/210-monitoring-set.yaml
@@ -27,7 +27,7 @@ spec:
       {{ if .imagePullSecrets.enabled }}
       imagePullSecrets:
       {{range .imagePullSecrets.value }}
-        - name: {{ .name }}
+        - name: {{ . }}
       {{ end }}
       {{ end }}
       containers:

--- a/src/deployment_templates/sawtooth/1.1/320-validator-set.yaml
+++ b/src/deployment_templates/sawtooth/1.1/320-validator-set.yaml
@@ -43,7 +43,7 @@ spec:
       {{ if .imagePullSecrets.enabled }}
       imagePullSecrets:
       {{range .imagePullSecrets.value }}
-        - name: {{ .name }}
+        - name: {{ . }}
       {{ end }}
       {{ end }}
       hostAliases:

--- a/src/deployment_templates/sawtooth/1.1/330-sawtooth-daml-rpc.yaml
+++ b/src/deployment_templates/sawtooth/1.1/330-sawtooth-daml-rpc.yaml
@@ -25,7 +25,7 @@ spec:
       {{ if .imagePullSecrets.enabled }}
       imagePullSecrets:
       {{range .imagePullSecrets.value }}
-        - name: {{ .name }}
+        - name: {{ . }}
       {{ end }}
       {{ end }}
       containers:

--- a/src/deployment_templates/sawtooth/1.1/form.js
+++ b/src/deployment_templates/sawtooth/1.1/form.js
@@ -349,6 +349,9 @@ const form = [
       visibilityParameter: 'true' // for what value of linkedId, will this component be visible
     },
     list: {
+      // this means we want an array of the `name` fields
+      // NOT an array of objects each with a name field
+      extractField: 'name',
       mainField: 'name',
       schema: [{
         id: 'name',

--- a/src/deployment_templates/taekion/0.1/210-monitoring-set.yaml
+++ b/src/deployment_templates/taekion/0.1/210-monitoring-set.yaml
@@ -27,7 +27,7 @@ spec:
       {{ if .imagePullSecrets.enabled }}
       imagePullSecrets:
       {{range .imagePullSecrets.value }}
-        - name: {{ .name }}
+        - name: {{ . }}
       {{ end }}
       {{ end }}
       containers:

--- a/src/deployment_templates/taekion/0.1/320-validator-set.yaml
+++ b/src/deployment_templates/taekion/0.1/320-validator-set.yaml
@@ -43,7 +43,7 @@ spec:
       {{ if .imagePullSecrets.enabled }}
       imagePullSecrets:
       {{range .imagePullSecrets.value }}
-        - name: {{ .name }}
+        - name: {{ . }}
       {{ end }}
       {{ end }}
       hostAliases:

--- a/src/deployment_templates/taekion/0.1/form.js
+++ b/src/deployment_templates/taekion/0.1/form.js
@@ -335,6 +335,9 @@ const form = [
       visibilityParameter: 'true' // for what value of linkedId, will this component be visible
     },
     list: {
+      // this means we want an array of the `name` fields
+      // NOT an array of objects each with a name field
+      extractField: 'name',
       mainField: 'name',
       schema: [{
         id: 'name',


### PR DESCRIPTION
…ray of strings not an array of objects

Signed-off-by: Kai Davenport <kaiyadavenport@gmail.com>

closes [SXT-461](https://blockchaintp.atlassian.net/browse/SXT-461)

**IMPORTANT** depends on https://github.com/catenasys/sextant/pull/152 (merge at same time)

This changes the deployment forms to configure and expect an array of strings rather than an array of objects for the image pull secrets