### PR TITLE
grpcurl should return packages as an array

### DIFF
--- a/src/api/damlRPC.js
+++ b/src/api/damlRPC.js
@@ -488,9 +488,7 @@ const DamlRPC = ({
         })
         const packages = response.packageDetails
 
-        const sortedPackages = packages.sort()
-
-        return sortedPackages
+        return packages.sort()
       },
     })
     return result


### PR DESCRIPTION
I'm not sure if the api for daml changed - but we were passing an empty data object through our api for getArchives. The array of packages we want to return is stored on the packageDetails property on the response object from the Grpcurl request. 

- I also removed the part of our code that was mapping each package to a new property called packageId. This nesting of the data from breaking the UI even after the response passed actual data
-
sxt-701

Signed-off-by: Mikeala Sheldt <mikaela@blockchaintp.com>