### PR TITLE
Disables sonarqube to ignore octal value and updates octal literal

### DIFF
--- a/src/utils/ssh-keygen.js
+++ b/src/utils/ssh-keygen.js
@@ -21,7 +21,7 @@ const createKeypair = (done) => {
     // create a temporary directory to work in
     (next) => {
       tmp.dir({
-        mode: 0o750,
+        mode: 0o750, // NOSONAR
         prefix: 'sshkeygen_',
         unsafeCleanup: true,
       }, (err, path, cleanup) => {


### PR DESCRIPTION
- linting
- updates octal literal to modern format ('0750' -> '0o750')
- Disables sonar from caring about octal value