### PR TITLE
fixes `cannot read sort of undefined` bug in the daml-archives page view

### DIFF
--- a/src/api/damlRPC.js
+++ b/src/api/damlRPC.js
@@ -488,7 +488,7 @@ const DamlRPC = ({
           })
           const packages = response.packageDetails
 
-          return packages
+          return packages ? packages.sort() : []
         },
       }))
     } catch (error) {


### PR DESCRIPTION
- adress sonar code smell 
- allow the there to be no packages when listing the packages with an immediately returned ternary
This was previously handled by passing in an empty array arg

sxt-723