### PR TITLE
track deployment history changes in a deployment_history table

### DIFF
--- a/migrations/202110051509_deployment_history_table.js
+++ b/migrations/202110051509_deployment_history_table.js
@@ -1,0 +1,21 @@
+const up = (knex) => Promise.all([
+  knex.schema.createTable('deployment_history', (table) => {
+    table.specificType('recorded_at', 'timestamp default now()')
+    table.integer('cluster_id')
+    table.integer('deployment_id')
+    table.string('name')
+    table.string('deployment_type')
+    table.string('deployment_version')
+    table.string('status')
+    table.json('helm_response').defaultTo('{}')
+  }),
+])
+
+const down = (knex) => Promise.all([
+  knex.schema.dropTable('deployment_history'),
+])
+
+module.exports = {
+  up,
+  down,
+}

--- a/src/jobs/pollUtils.js
+++ b/src/jobs/pollUtils.js
@@ -130,6 +130,7 @@ const processHelmResponse = (helmResponse, deployment) => {
   const translatedStatus = translateStatus(helmStatus)
 
   const processedHelmResponse = { helm_response: helmResponse }
+  processedHelmResponse.helmStatus = helmStatus
   processedHelmResponse.name = deployment.name
   processedHelmResponse.cluster_id = deployment.cluster
   processedHelmResponse.status = translatedStatus
@@ -146,7 +147,7 @@ const updateStatus = async (processedHelmResponse, store) => {
   const databaseResponse = await store.deployment
     .updateStatus({
       id: processedHelmResponse.deployment_id,
-      time: processedHelmResponse.time,
+      helm_response: processedHelmResponse.helm_response,
       data: {
         status: processedHelmResponse.status,
         updated_at: processedHelmResponse.updated_at,

--- a/src/store/deploymenthistory.js
+++ b/src/store/deploymenthistory.js
@@ -1,0 +1,79 @@
+const logger = require('../logging').getLogger({
+  name: ' DeploymentHistoryStore',
+})
+
+const DeploymentHistoryStore = (knex) => {
+  const list = (trx) => (trx || knex).select('*')
+    .from('deployment_history')
+
+  const get = ({
+    deployment_id,
+    limit,
+    first,
+  }, trx) => {
+    if (!deployment_id) throw new Error('id must be given to store.deploymentresult.get')
+
+    if (first) {
+      return (trx || knex).select('*')
+        .from('deployment_history')
+        .where({ deployment_id })
+        .orderBy('recorded_at', 'desc')
+        .limit(limit)
+        .first()
+    }
+    if (limit) {
+      return (trx || knex).select('*')
+        .from('deployment_history')
+        .where({ deployment_id })
+        .orderBy('recorded_at', 'desc')
+        .limit(limit)
+    }
+    return (trx || knex).select('*')
+      .from('deployment_history')
+      .where({ deployment_id })
+      .orderBy('recorded_at', 'desc')
+  }
+
+  const create = async ({
+    data: {
+      cluster_id,
+      deployment_id,
+      name,
+      deployment_type,
+      deployment_version,
+      status,
+      helm_response,
+    },
+  }, trx) => {
+    if (!name) throw new Error('data.name param must be given to store.deploymentresult.create')
+    if (!status) throw new Error('data.status param must be given to store.deploymentresult.create')
+    if (!deployment_id) throw new Error('data.deployment_id param must be given to store.deploymentresult.create')
+
+    const [result] = await (trx || knex)('deployment_history')
+      .insert({
+        cluster_id,
+        deployment_id,
+        name,
+        deployment_type,
+        deployment_version,
+        status,
+        helm_response,
+      })
+      .returning('*')
+    logger.debug({
+      message: `New result recorded for ${result.name}.`,
+      deployment_id: result.deployment_id,
+      status: result.status,
+    })
+
+    return result
+  }
+
+  return {
+    list,
+    get,
+    create,
+  }
+}
+
+module.exports = DeploymentHistoryStore

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -7,6 +7,7 @@ const DeploymentStore = require('./deployment')
 const DeploymentSecretStore = require('./deploymentsecret')
 const TaskStore = require('./task')
 const SettingsStore = require('./settings')
+const DeploymentHistoryStore = require('./deploymenthistory')
 
 const Store = (knex) => {
   const user = UserStore(knex)
@@ -18,8 +19,9 @@ const Store = (knex) => {
   const deploymentsecret = DeploymentSecretStore(knex)
   const task = TaskStore(knex)
   const settings = SettingsStore(knex)
+  const deploymenthistory = DeploymentHistoryStore(knex)
 
-  const transaction = handler => knex.transaction(handler)
+  const transaction = (handler) => knex.transaction(handler)
 
   return {
     knex,
@@ -33,6 +35,7 @@ const Store = (knex) => {
     task,
     transaction,
     settings,
+    deploymenthistory,
   }
 }
 


### PR DESCRIPTION
currently getting ```TypeError: Cannot destructure property 'cluster_id' of 'task.playload' as it is undefined.
    at completeTask (/app/api/src/tasks/resource_updaters/deploymentStatusUpdaters.js:55:5)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)```
when creating a deployment. Though, when I log these values, they are in fact defined. I'm clearly missing something.