### PR TITLE
build(vercel): Use GitHub action to deploy docs preview

### DIFF
--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -1,0 +1,44 @@
+name: Vercel Preview Docs Deployment
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+
+jobs:
+  Deploy-Preview:
+    if: contains(github.event.pull_request.labels.*.name, 'documentation') || contains (github.label, 'documentation')
+    runs-on: ubuntu-latest
+    steps:
+      - id: step1
+        uses: actions/checkout@v2
+      - id: step2
+        name: Install Vercel CLI
+        run: npm install --global vercel@canary
+      - id: step3
+        name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      - id: step4
+        name: Build Project Artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - id: step5
+        name: Deploy Project Artifacts to Vercel and get preview URL
+        run: echo preview="$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} )" >> $GITHUB_ENV
+      - id: step6
+        name: Comment with Preview URL
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Docs preview: ${{ env.preview }}`
+            })

--- a/.github/workflows/vercel-production.yaml
+++ b/.github/workflows/vercel-production.yaml
@@ -1,0 +1,22 @@
+---
+name: Vercel Production Docs Deployment
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+on:
+  push:
+    branches:
+      - main
+jobs:
+  Deploy-Production:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Vercel CLI
+        run: npm install --global vercel@canary
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,7 +88,7 @@ repos:
     rev: v1.29.0
     hooks:
       - id: yamllint
-        exclude: ".*/templates/.*"
+        exclude: "^(.github/workflows/*.*)$"
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v2.1.1
     hooks:

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,8 @@
   "buildCommand": "mkdocs build",
   "github": {
     "silent": true
+  },
+  "git": {
+    "deploymentEnabled": false
   }
 }


### PR DESCRIPTION
This removes the built in Vercel Github integration, and instead uses Github actions. 
It will deploy to the Vercel production site on mush to `master`
When a PR is opened no Vercel preview will be generated until a label of `[documentation]` is added.

DOPS-54